### PR TITLE
revision routing

### DIFF
--- a/src/components/common/atoms/CommonButton.css
+++ b/src/components/common/atoms/CommonButton.css
@@ -11,15 +11,9 @@
   background: var(--white);
 }
 .common-footer button {
-  background: var(--bgGray);
-  color: var(--mainGray);
   border: none;
   width: 113px;
   height: 50px;
   border-radius: 6px;
   font-weight: bold;
-}
-.common-footer button.active {
-  color: var(--white);
-  background: var(--mainBlue);
 }

--- a/src/components/common/atoms/CommonButton.js
+++ b/src/components/common/atoms/CommonButton.js
@@ -1,19 +1,20 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import "./CommonButton.css";
 
-const CommonButton = ({ isPostingButton, commonBtnText }) => {
+const CommonButton = ({ isPostingButton, commonBtnText, CommonButtonLink }) => {
+  const navigate = useNavigate();
+  console.log(CommonButtonLink);
   return (
     <div className="common-footer">
-      <Link to="/tipslist">
-        <button
-          style={
-            isPostingButton ? style.commonTrueButton : style.commonFalseButton
-          }
-        >
-          {commonBtnText}
-        </button>
-      </Link>
+      <button
+        style={
+          isPostingButton ? style.commonTrueButton : style.commonFalseButton
+        }
+        onClick={() => navigate(`/${CommonButtonLink}`)}
+      >
+        {commonBtnText}
+      </button>
     </div>
   );
 };

--- a/src/screens/NewPost/NewPost.js
+++ b/src/screens/NewPost/NewPost.js
@@ -65,6 +65,7 @@ const NewPost = () => {
       <CommonButton
         commonBtnText="投稿する"
         isPostingButton={isPostingButton}
+        CommonButtonLink="tipslist"
       />
     </>
   );

--- a/src/screens/TipsList/TipsList.js
+++ b/src/screens/TipsList/TipsList.js
@@ -1,7 +1,7 @@
 //index
 import React from "react";
 import { useSelector } from "react-redux";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import CommonButton from "../../components/common/atoms/CommonButton";
 import HeaderMenu from "../../components/common/molecules/HeaderMenu";
 import "./TipsList.css";
@@ -10,6 +10,7 @@ const TipsList = () => {
   const navigate = useNavigate();
   const tipsData = useSelector((state) => state.tips.tipsData);
   const currentUserId = "aaa";
+  const isPostingButton = true;
   return (
     <>
       <div className="inner" style={style.inner}>
@@ -45,9 +46,12 @@ const TipsList = () => {
           })}
         </div>
       </div>
-      <Link to="/newpost">
-        <CommonButton commonBtnText="新規投稿" active="active" />
-      </Link>
+
+      <CommonButton
+        commonBtnText="新規投稿"
+        isPostingButton={isPostingButton}
+        CommonButtonLink="newpost"
+      />
     </>
   );
 };


### PR DESCRIPTION
# CommonButton.jsのルーティング修正
> `CommonButton.js`のルーティングについて、親コンポーネントによって遷移先が違うため仕様を修正しました。
LinkではなくuseNavigateを使い、遷移先のパスパラメーターをpropsで渡すようにします。