### PR TITLE
switch button  

### DIFF
--- a/src/components/Auth/molecules/InputFormHeader.js
+++ b/src/components/Auth/molecules/InputFormHeader.js
@@ -1,10 +1,15 @@
 import React from "react";
 
-const InputFormHeader = ({ title, desc, errorMsg }) => {
+const InputFormHeader = ({ title, desc, descStyle }) => {
+  console.log("style", style);
   return (
     <div className="input-header">
       <h1>{title}</h1>
-      <p style={errorMsg ? style.authFalseDesc : style.authTrueDesc}>{desc}</p>
+      <p
+        style={descStyle === "error" ? style.authFalseDesc : style.authTrueDesc}
+      >
+        {desc}
+      </p>
     </div>
   );
 };

--- a/src/screens/Auth/Auth.js
+++ b/src/screens/Auth/Auth.js
@@ -8,11 +8,30 @@ import "./Auth.css";
 const Auth = () => {
   const [isSignUp, setIsSignUp] = useState(false);
   const [authError, setAuthError] = useState(false);
-  const [errorMsg, setErrorMsg] = useState(false);
+
   const [fromData, setFormData] = useState({
     email: "",
     password: "",
   });
+
+  const switchRegister = () => {
+    setIsSignUp(false);
+  };
+  const switchLogin = () => {
+    setIsSignUp(true);
+  };
+
+  const authDesc = () => {
+    if (authError === true) {
+      if (isSignUp) {
+        return "入力情報が一致しませんでした。\nもう一度お試しください。";
+      } else {
+        return "登録できませんでしたので、もう一度お試しください。";
+      }
+    } else {
+      return "メールアドレスとパスワードを入力してください";
+    }
+  };
 
   const inputFormChange = (e) => {
     //name属性を含む要素の値をとる
@@ -24,12 +43,8 @@ const Auth = () => {
       <div className="inner" style={style.inner}>
         <InputFormHeader
           title={isSignUp ? "ログイン" : "新規登録"}
-          desc={
-            authError
-              ? "入力情報が一致しませんでした。\nもう一度お試しください。"
-              : "メールアドレスとパスワードを入力してください"
-          }
-          errorMsg={errorMsg}
+          desc={authDesc()}
+          descStyle={authError && "error"}
         />
         <InputForm />
         <InputButton btnText={isSignUp ? "ログイン" : "新規登録"} />
@@ -37,11 +52,13 @@ const Auth = () => {
           <p>
             {isSignUp ? (
               <span>
-                アカウントをお持ちでないですか?<button>&nbsp;新規登録</button>
+                アカウントをお持ちでないですか?
+                <button onClick={() => switchRegister()}>&nbsp;新規登録</button>
               </span>
             ) : (
               <span>
-                アカウントをお持ちですか?<button>&nbsp;ログイン</button>
+                アカウントをお持ちですか?
+                <button onClick={() => switchLogin()}>&nbsp;ログイン</button>
               </span>
             )}
           </p>


### PR DESCRIPTION
# 新規登録とログインの画面を切り替え
> フォームボタンの下の「新規登録」「ログイン」のテキストをクリックして、画面を新規登録用とログイン用で切り替えるようにしました。
使用しているステートはisSignUpのみです。

# InputFormHeaderの説明文の修正
> 説明文に関するステートに誤りがあったので修正しています。
- テキストの出力内容について
　 新規登録時とログイン時で違うためauthDesc()という関数で「入力エラーがあるか？」「ユーザーはアカウント作成済みか？」を判定して、テキストを出し分けるようにしています。
- エラー時のスタイルについて
　今まではerrorMsgというステートで管理していましたが不要になったので削除しています。あくまでauthErrorの値と同じになるためです。