### PR TITLE
AccoutDelete-routing MypostDelete-routing

### DIFF
--- a/src/components/common/molecules/ModalMenu.js
+++ b/src/components/common/molecules/ModalMenu.js
@@ -42,7 +42,7 @@ const ModalMenu = ({ menuToggle, menuCloseHandler }) => {
                 <span>ログアウト</span>
               </li>
             </Link>
-            <Link to="/account-delete" onClick={menuCloseHandler}>
+            <Link to="/accountdelete" onClick={menuCloseHandler}>
               <li>
                 <img src={SignOutImg} alt="SignOut" />
                 <span>退会</span>

--- a/src/screens/AccountDelete/AccountDelete.js
+++ b/src/screens/AccountDelete/AccountDelete.js
@@ -5,6 +5,8 @@ import HeaderMenu from "../../components/common/molecules/HeaderMenu";
 import "./AccountDelete.css";
 
 const AccountDelete = () => {
+  const isPostingButton = true;
+
   return (
     <>
       <div className="inner" style={style.inner}>
@@ -20,7 +22,11 @@ const AccountDelete = () => {
           </p>
         </div>
       </div>
-      <CommonButton commonBtnText="退会する" />
+      <CommonButton
+        commonBtnText="退会する"
+        isPostingButton={isPostingButton}
+        CommonButtonLink=""
+      />
     </>
   );
 };

--- a/src/screens/MypostDelete/MypostDelete.js
+++ b/src/screens/MypostDelete/MypostDelete.js
@@ -6,6 +6,8 @@ import HeaderMenu from "../../components/common/molecules/HeaderMenu";
 import "./MypostDelete.css";
 
 const MypostDelete = () => {
+  const isPostingButton = true;
+
   return (
     <>
       <div className="inner">
@@ -19,7 +21,11 @@ const MypostDelete = () => {
         </div>
       </div>
       <Link to="/tipslist">
-        <CommonButton commonBtnText="削除する" active="active" />
+        <CommonButton
+          commonBtnText="削除する"
+          isPostingButton={isPostingButton}
+          CommonButtonLink="tipslist"
+        />
       </Link>
     </>
   );

--- a/src/screens/TipsDetail/TipsDetail.js
+++ b/src/screens/TipsDetail/TipsDetail.js
@@ -11,6 +11,7 @@ const TipsDetail = () => {
   const tipsData = useSelector((state) => state.tips.tipsData);
   const tipsDetail = tipsData.filter((tips) => tips.id === params.id);
   const currentUserId = "aaa";
+  const isPostingButton = true;
 
   return (
     <>
@@ -27,7 +28,11 @@ const TipsDetail = () => {
       </div>
       {currentUserId === tipsDetail[0].userId && (
         <Link to="/postdelete">
-          <CommonButton commonBtnText="削除する" active="active" />
+          <CommonButton
+            commonBtnText="削除する"
+            isPostingButton={isPostingButton}
+            CommonButtonLink="mypostdelete"
+          />
         </Link>
       )}
     </>


### PR DESCRIPTION
# AccountDeleteのルーティング
> AccountDeleteで退会ボタンを押した時にログイン画面に遷移するように実装しました。
また`ModalMenu.js`にてAccountDeleteへの遷移に誤りがあったので併せて修正しています。
画面遷移にはuseNavigateを使用しました。

# MypostDeleteのルーティング
> `TipsDetail.js`と`MypostDelete.js`での` CommonButton.js`へのpropsに誤りがあったので修正しています。
自分の投稿を削除した際にTipsListに遷移するようになりました。
画面遷移にはuseNavigateを使用しました。