### PR TITLE
post firestore and storage

### DIFF
--- a/src/components/common/atoms/CommonButton.js
+++ b/src/components/common/atoms/CommonButton.js
@@ -1,19 +1,14 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
 import "./CommonButton.css";
 
-const CommonButton = ({ isPostingButton, commonBtnText, CommonButtonLink }) => {
-  const navigate = useNavigate();
-  const CommonButtonNavigate = () => {
-    isPostingButton && navigate(`/${CommonButtonLink}`);
-  };
+const CommonButton = ({ isPostingButton, commonBtnText, onClick }) => {
   return (
     <div className="common-footer">
       <button
         style={
           isPostingButton ? style.commonTrueButton : style.commonFalseButton
         }
-        onClick={() => CommonButtonNavigate()}
+        onClick={onClick}
       >
         {commonBtnText}
       </button>

--- a/src/screens/TipsList/TipsList.js
+++ b/src/screens/TipsList/TipsList.js
@@ -1,7 +1,7 @@
 //index
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Outlet, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import CommonButton from "../../components/common/atoms/CommonButton";
 import HeaderMenu from "../../components/common/molecules/HeaderMenu";
 import "./TipsList.css";
@@ -14,6 +14,10 @@ const TipsList = () => {
 
   const currentUserId = "aaa";
   const isPostingButton = true;
+
+  const linkToNewpost = () => {
+    isPostingButton && navigate("/newpost");
+  };
 
   useEffect(() => {
     dispatch(fetchTips());
@@ -61,6 +65,7 @@ const TipsList = () => {
         commonBtnText="新規投稿"
         isPostingButton={isPostingButton}
         CommonButtonLink="newpost"
+        onClick={() => linkToNewpost()}
       />
     </>
   );


### PR DESCRIPTION
# firestoreとstorageへの投稿機能
> 画像の投稿を実装しました。
storageに投稿した画像をURLの状態でfirestoreに同じIDを探して追加する形です。
画像の取得に関しては未実装です。

# CommonButton.jsの仕様変更
> ` CommonButton.js`へ渡すonClick関数について、これまでの画面遷移の他に投稿や削除など他の関数を渡す必要があります。
今後は各自のコンポーネントで画面遷移を含む一連の動きを一つの関数にまとめてpropsで` CommonButton.js`に渡す
ように変更します。
そのため`CommonButton.js`の中でonClick関数は定義しないことになります。