### PR TITLE
fix timestamp in NewPost.js

### DIFF
--- a/src/screens/MypostDelete/MypostDelete.js
+++ b/src/screens/MypostDelete/MypostDelete.js
@@ -10,6 +10,7 @@ const MyPostDelete = () => {
   const location = useLocation();
   const { imagePath } = location.state;
   const navigate = useNavigate();
+  
   const deleteMyTips = async () => {
     await deleteDoc(doc(db, "tips", location.state.tipsId));
     const deleteRef = ref(storage, imagePath);

--- a/src/screens/NewPost/NewPost.js
+++ b/src/screens/NewPost/NewPost.js
@@ -56,7 +56,8 @@ const NewPost = () => {
               userId: currentUserId,
               title: tipsTitle,
               desc: tipsDesc,
-              timestamp: serverTimestamp(),
+              // timestamp: serverTimestamp(),
+              timestamp: currentDate,
               thumbnail: downloadThumbnail,
             });
           }


### PR DESCRIPTION
# 新規投稿時のタイムスタンプを修正
storageとfirestoreは同じタイミングで実行されないため、タイムスタンプにズレが起きていました。
storageで使ったタイムスタンプをfirestoreでのタイムスタンプにも使い回すことで解決しました。